### PR TITLE
Init cog & init sprintlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## Unreleased ([a8095c9..1d5d5d7](https://github.com/uni-tj/robo-arena/compare/a8095c9..1d5d5d7))
+#### Miscellaneous Chores
+- init cog - ([1d5d5d7](https://github.com/uni-tj/robo-arena/commit/1d5d5d7a653f8b5dcd485bbec0653eaa0844a00a)) - [@p-98](https://github.com/p-98)
+- init sprintlog - ([82a83bb](https://github.com/uni-tj/robo-arena/commit/82a83bb1ccb4b3ec59d3fbffebaf75d722089659)) - [@p-98](https://github.com/p-98)
+- initial commit - ([a8095c9](https://github.com/uni-tj/robo-arena/commit/a8095c927ad5ae1841cd8fafcdb1b321509ed554)) - [@p-98](https://github.com/p-98)
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Installation
+
+Clone repository:
+
+```sh
+git clone https://github.com/uni-tj/robo-arena
+```
+
+Install git hooks:
+
+```sh
+cog install-hook --all
+```

--- a/SPRINTLOG.md
+++ b/SPRINTLOG.md
@@ -1,0 +1,14 @@
+# Robo-Arena Changelog
+
+## Sprint 1
+
+Branch protection on `main`:
+
+- require pull request before merging
+  - require approval
+  - approvals don't become stale with new commits to speed up review process. Changed when bugs are introduced hereby.
+- require status checks to pass before merging
+- require branch to be up to date. Prevents bugs introduced in merge commits
+- require conversion resolution
+- require linear history. For easier understanding of history.
+- allow force pushes. As per sprint spec.

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,39 @@
+from_latest_tag = false
+ignore_merge_commits = false
+disable_changelog = false
+disable_bump_commit = false
+generate_mono_repository_global_tag = true
+branch_whitelist = []
+skip_ci = "[skip ci]"
+skip_untracked = false
+pre_bump_hooks = []
+post_bump_hooks = []
+pre_package_bump_hooks = []
+post_package_bump_hooks = []
+
+[git_hooks.commit-msg]
+script = """
+  #!/bin/sh
+  set -e
+  cog verify --file $1
+  cog check
+"""
+
+[commit_types]
+
+[changelog]
+path = "CHANGELOG.md"
+template = "remote"
+remote = "github.com"
+repository = "robo-arena"
+owner = "uni-tj"
+authors = [
+  { signature = "weiserhase", username = "weiserhase" },
+  { signature = "JulesOxe", username = "JulesOxe" },
+  { signature = "p-98", username = "p-98" },
+  { signature = "p98", username = "p-98" },
+]
+
+[bump_profiles]
+
+[packages]


### PR DESCRIPTION
Initialize sprintlog to keep track of progress of sprints. 

Initialize cog with pre-commit git hook and changelog and add documentation for it.