### PR TITLE
Refactoring: Make renderctx internal

### DIFF
--- a/src/roboarena/shared/block.py
+++ b/src/roboarena/shared/block.py
@@ -2,12 +2,15 @@ import logging
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pygame
 from pygame import Surface
 
-from roboarena.shared.rendering.render_ctx import RenderingCtx
 from roboarena.shared.utils.vector import Vector
+
+if TYPE_CHECKING:
+    from roboarena.shared.rendering.render_ctx import RenderCtx
 
 logger = logging.getLogger(f"{__name__}")
 STANDARD_BLOCK_SIZE_PX = 50
@@ -19,7 +22,7 @@ class Block(ABC):
     dimensions_px: Vector[int]
 
     # @log_durations(logger.debug, "render_block: ", "ms")
-    def render_block(self, ctx: RenderingCtx, block_pos_px: Vector[float]) -> None:
+    def render_block(self, ctx: "RenderCtx", block_pos_px: Vector[float]) -> None:
         corrected_block_pos_px: tuple[float, float] = (
             block_pos_px
             + ctx.scale_vector(Vector(0, STANDARD_BLOCK_SIZE_PX - self.dimensions_px.y))

--- a/src/roboarena/shared/entity.py
+++ b/src/roboarena/shared/entity.py
@@ -4,13 +4,16 @@ from typing import TYPE_CHECKING
 
 from pygame import Rect, Surface
 
-from roboarena.shared.rendering.render_ctx import FieldOfView, RenderingCtx
 from roboarena.shared.time import Time
 from roboarena.shared.types import Color, Input, Motion, Position
 from roboarena.shared.utils.vector import Vector
 
 if TYPE_CHECKING:
     from roboarena.shared.game import GameState
+    from roboarena.shared.rendering.render_ctx import RenderCtx
+    from roboarena.shared.types import FieldOfView
+
+logger = logging.getLogger(f"{__name__}")
 
 logger = logging.getLogger(f"{__name__}")
 
@@ -34,7 +37,7 @@ class Entity(ABC):
     @abstractmethod
     def position(self) -> Position: ...
 
-    def visible_in_fov(self, fov: FieldOfView) -> bool:
+    def visible_in_fov(self, fov: "FieldOfView") -> bool:
         position = self.position
         return (
             position.x >= fov[0].x
@@ -43,7 +46,7 @@ class Entity(ABC):
             and position.y <= fov[1].y
         )
 
-    def render(self, ctx: RenderingCtx) -> None:
+    def render(self, ctx: "RenderCtx") -> None:
         if not self.visible_in_fov(ctx.fov):
             return
 
@@ -52,8 +55,8 @@ class Entity(ABC):
         entity_pos_px: Vector[float] = ctx.screen_dimenions_px * Vector(0.5, 0.5) - (
             ctx.camera_position_gu - entity_pos_gu
         ) * Vector(ctx.px_per_gu, ctx.px_per_gu)
-        corrected_entity_pos_px: tuple[float, float] = ctx.scale_vector(
-            entity_pos_px - entity_dim_px * 0.5
+        corrected_entity_pos_px: tuple[float, float] = (
+            entity_pos_px - ctx.scale_vector(entity_dim_px * 0.5)
         ).tuple_repr()
         ctx.screen.blit(ctx.scale_texture(self.texture), corrected_entity_pos_px)
 

--- a/src/roboarena/shared/rendering/render_ctx.py
+++ b/src/roboarena/shared/rendering/render_ctx.py
@@ -1,44 +1,57 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pygame
 from pygame import Surface
 
 from roboarena.shared.utils.vector import Vector
 
-# representing the upper left and lower right corners of the field of view
-type FieldOfView = tuple[Vector[int], Vector[int]]
+if TYPE_CHECKING:
+    from roboarena.shared.types import FieldOfView
 
 STANDARD_BLOCK_SIZE_PX = 50
 STANDARD_GU_PER_SCREEN = 15
 OVERLAP_FOV_GU = Vector(2.0, 2.0)
 
 
+logger = logging.getLogger(f"{__name__}")
+
+
 # @dataclass(frozen=True)
-class RenderingCtx:
+class RenderCtx:
     screen: Surface
     screen_dimenions_px: Vector[int]
     camera_position_gu: Vector[float]
-    fov: FieldOfView
+    fov: "FieldOfView"
     px_per_gu: int
     scale_factor: float
-    _scale_cache: dict[Surface, Surface] = {}
-    _logger = logging.getLogger(f"{__name__}.RenderingCtx")
+    _scale_cache: dict[Surface, Surface]
+    _logger = logging.getLogger(f"{__name__}.RenderCtx")
 
-    def __init__(self, screen: Surface):
+    def __init__(
+        self,
+        screen: Surface,
+        camera_position_gu: Vector[float],
+        scale_cache: dict[Surface, Surface],
+    ):
         self.screen = screen
-        self.update_screen_dimensions(Vector(screen.get_width(), screen.get_height()))
-        self.update_camera_position(Vector(0.0, 0.0))
+        self._scale_cache = scale_cache
+        self.update_screen_dimensions()
+        self.update_camera_position(camera_position_gu)
 
     def update_camera_position(self, camera_position_gu: Vector[float]):
         self.camera_position_gu = camera_position_gu
         self.fov = self.update_fov()
+        logging.info(f"fov: {self.fov}")
 
-    def update_screen_dimensions(self, screen_dimensions_px: Vector[int]):
-        self.screen_dimenions_px = screen_dimensions_px
+    def update_screen_dimensions(self):
+        self.screen_dimenions_px = Vector(
+            self.screen.get_width(), self.screen.get_height()
+        )
         self.update_scale()
         self._scale_cache = {}
 
-    def update_fov(self) -> FieldOfView:
+    def update_fov(self) -> "FieldOfView":
         center_to_corner_distance_gu: Vector[float] = (
             self.screen_dimenions_px
             * Vector(1 / self.px_per_gu, 1 / self.px_per_gu)
@@ -73,3 +86,6 @@ class RenderingCtx:
 
     def scale_vector(self, vector: Vector[float]) -> Vector[float]:
         return vector * self.scale_factor
+
+    def get_scale_cache(self) -> dict[Surface, Surface]:
+        return self._scale_cache

--- a/src/roboarena/shared/types.py
+++ b/src/roboarena/shared/types.py
@@ -1,14 +1,17 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import pygame
 
 from roboarena.server.level_generation.tile import Tile
-from roboarena.shared.block import Block
 from roboarena.shared.network import IpV4
 from roboarena.shared.time import Time
 from roboarena.shared.utils.vector import Vector
+
+if TYPE_CHECKING:
+    from roboarena.shared.block import Block
+    from roboarena.shared.entity import Entity
 
 type Acknoledgement = int
 INITIAL_ACKNOLEDGEMENT: Acknoledgement = -1
@@ -21,7 +24,11 @@ type Motion = tuple[Position, Orientation]
 type Color = pygame.Color
 
 type TileMap = dict[Vector[int], Optional[Tile]]
-type Level = dict[Vector[int], Block]
+type Level = dict[Vector[int], "Block"]
+
+type Entities = dict[EntityId, "Entity"]
+
+type FieldOfView = tuple[Vector[int], Vector[int]]
 
 
 """Communication protocol


### PR DESCRIPTION
RenderCtx is now internal and only accesed by the render engine. You only need the render engine to render the screen now.