### PR TITLE
Quit gracefully

### DIFF
--- a/src/roboarena/client/client.py
+++ b/src/roboarena/client/client.py
@@ -8,25 +8,38 @@ from pygame import RESIZABLE, Surface, event
 from pygame.font import Font
 from pygame.time import Clock
 
-from roboarena.client.entity import (ClientEnemyRobot, ClientEntityType,
-                                     ClientInputHandler, ClientPlayerRobot)
+from roboarena.client.entity import (
+    ClientEnemyRobot,
+    ClientEntityType,
+    ClientInputHandler,
+    ClientPlayerRobot,
+)
 from roboarena.shared.constants import CLIENT_TIMESTEP, SERVER_IP
 from roboarena.shared.custom_threading import Atom
 from roboarena.shared.game import GameState as SharedGameState
 from roboarena.shared.network import Arrived, IpV4, Network
 from roboarena.shared.rendering.render_engine import RenderEngine
 from roboarena.shared.time import Time, get_time
-from roboarena.shared.types import (INITIAL_ACKNOLEDGEMENT, Acknoledgement,
-                                    ClientConnectionRequestEvent,
-                                    ClientGameEvent, ClientGameEventType,
-                                    ClientId, ClientInputEvent,
-                                    ClientLobbyReadyEvent, EntityId, EventType,
-                                    Input, ServerConnectionConfirmEvent,
-                                    ServerEntityEvent, ServerExtendLevelEvent,
-                                    ServerGameEvent, ServerGameStartEvent,
-                                    ServerSpawnRobotEvent)
-from roboarena.shared.util import (Counter, EventTarget, Stoppable, Stopped,
-                                   counter)
+from roboarena.shared.types import (
+    INITIAL_ACKNOLEDGEMENT,
+    Acknoledgement,
+    ClientConnectionRequestEvent,
+    ClientGameEvent,
+    ClientGameEventType,
+    ClientId,
+    ClientInputEvent,
+    ClientLobbyReadyEvent,
+    EntityId,
+    EventType,
+    Input,
+    ServerConnectionConfirmEvent,
+    ServerEntityEvent,
+    ServerExtendLevelEvent,
+    ServerGameEvent,
+    ServerGameStartEvent,
+    ServerSpawnRobotEvent,
+)
+from roboarena.shared.util import Counter, EventTarget, Stoppable, Stopped, counter
 from roboarena.shared.utils.vector import Vector
 
 
@@ -225,7 +238,7 @@ class GameState(SharedGameState):
             for e in event.get():
                 match e.type:
                     case pygame.QUIT:
-                        self.events.dispatch_event(QuitEvent())
+                        self.events.dispatch(QuitEvent())
                     case _:
                         continue
 
@@ -303,7 +316,7 @@ class Client(Stoppable):
         self._logger.info("Started game")
 
         game_state = GameState(self, screen, client_id, start[0], start[1])
-        game_state.events.add_event_listener(QuitEvent, self.events.dispatch_event)
+        game_state.events.add_listener(QuitEvent, self.events.dispatch)
         return game_state.loop()
 
     def stop(self) -> None:

--- a/src/roboarena/index.py
+++ b/src/roboarena/index.py
@@ -46,7 +46,7 @@ server_thread.start()
 logger.info("started server")
 
 client = Client(network, 0x00000001)
-client.events.add_event_listener(QuitEvent, lambda e: stopAll(client, server))
+client.events.add_listener(QuitEvent, lambda e: stopAll(client, server))
 client.loop()
 logger.info("stopped client")
 

--- a/src/roboarena/shared/util.py
+++ b/src/roboarena/shared/util.py
@@ -64,6 +64,13 @@ def getBounds(position: list[Vector[int]]) -> tuple[Vector[int], Vector[int]]:
 
 
 class EventTarget[Evt]:
+    """Class for emiting and listening to events.
+
+    Event handlers are called synchronousely.
+
+    Inheriting from this class is discouraged. Rather keep it as property `events`.
+    """
+
     _logger = logging.getLogger(f"{__name__}.EventTarget")
     """Dict from reference to original listener to internal listener"""
     _listeners: dict[Callable[[Any], None], Callable[[Evt], None]]
@@ -71,17 +78,17 @@ class EventTarget[Evt]:
     def __init__(self) -> None:
         self._listeners = {}
 
-    def add_event_listener[S](self, typ: type[S], listener: Callable[[S], None]):
+    def add_listener[S](self, typ: type[S], listener: Callable[[S], None]):
         def _listener(e: Evt):
             if isinstance(e, typ):
                 listener(e)
 
         self._listeners[listener] = _listener
 
-    def remove_event_listener(self, listener: Callable[[Evt], None]):
+    def remove_listener(self, listener: Callable[[Evt], None]):
         del self._listeners[listener]
 
-    def dispatch_event(self, event: Evt) -> None:
+    def dispatch(self, event: Evt) -> None:
         for listener in self._listeners.values():
             listener(event)
 


### PR DESCRIPTION
Quit the game cracefully when clicking the red cross of the os window.  
I. e. the pygame quit event is handled properly and every running object has the opportunity to clean up after themselves.

Minor technical changes:
-  all class variables are converted to instance variables where intended as such
- methods of `EventTarget` are renamed to shorten `self.events.dispatch_event(...)` to `self.events.dispatch(...)` as inheritance is discouraged anyways.

Resolves #28