### PR TITLE
Unique blocks & simplify level conversion

### DIFF
--- a/src/roboarena/server/level_generation/level_generator.py
+++ b/src/roboarena/server/level_generation/level_generator.py
@@ -4,7 +4,7 @@ from typing import List
 from funcy import log_durations
 
 from roboarena.server.level_generation.level_config import UCM
-from roboarena.server.level_generation.level_processing import tilesmap2levelmap
+from roboarena.server.level_generation.level_processing import tiles2level
 from roboarena.server.level_generation.wfc import (
     WFC,
     ConstraintMap,
@@ -44,7 +44,7 @@ class LevelGenerator:
 
     def get_level(self) -> Level:
         tm = self.wfc.tiles
-        new_level: Level = tilesmap2levelmap(tm, self.tilesize)
+        new_level: Level = tiles2level(tm, self.tilesize)
         if self.new_diff:
             self.last_level = new_level
             self.new_diff = False

--- a/src/roboarena/server/level_generation/tile.py
+++ b/src/roboarena/server/level_generation/tile.py
@@ -1,13 +1,15 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
 
-from roboarena.shared.block import BlockCtx
+if TYPE_CHECKING:
+    from roboarena.shared.block import Block
 
 
 @dataclass(frozen=True)
 class Tile:
     type: "TileType"
-    blocks: list[list[BlockCtx]]
+    blocks: list[list["Block"]]
 
 
 @dataclass(frozen=True)

--- a/src/roboarena/shared/block.py
+++ b/src/roboarena/shared/block.py
@@ -1,14 +1,14 @@
 import logging
 from abc import ABC
-from dataclasses import dataclass
-from functools import cached_property
-from pathlib import Path
+from dataclasses import dataclass, field
+from functools import cache, cached_property
 from typing import TYPE_CHECKING
 
 import pygame
 from pygame import Surface
 
 from roboarena.shared.rendering.util import size_from_texture
+from roboarena.shared.util import load_graphic
 from roboarena.shared.utils.vector import Vector
 
 if TYPE_CHECKING:
@@ -36,25 +36,30 @@ class Block(ABC):
         ctx.screen.blit(scaled_texture, ctx.gu2screen(top_left_gu).to_tuple())
 
 
+wall_texture = load_graphic("walls/wall-top.PNG")
+
+
 @dataclass(frozen=True)
-class BlockCtx(ABC):
-    graphics_path: Path
-    collision: bool
-
-
 class WallBlock(Block):
-    pass
+    texture: Surface = field(default=wall_texture)
 
 
+floor_texture = load_graphic("floor/floor2.PNG")
+
+
+@dataclass(frozen=True)
 class FloorBlock(Block):
-    pass
+    texture: Surface = field(default=floor_texture)
 
 
+@cache
+def load_void_texture() -> Surface:
+    voidTexture = Surface((50, 65))
+    voidTexture.fill((0, 0, 0))
+    pygame.draw.circle(voidTexture, "blue", (25, 40), 10)
+    return voidTexture
+
+
+@dataclass(frozen=True)
 class VoidBlock(Block):
-    pass
-
-
-voidTexture = Surface((50, 65))
-voidTexture.fill((0, 0, 0))
-pygame.draw.circle(voidTexture, "blue", (25, 40), 10)
-voidBlock = VoidBlock(voidTexture)
+    texture: Surface = field(default_factory=load_void_texture)

--- a/src/roboarena/shared/rendering/renderer.py
+++ b/src/roboarena/shared/rendering/renderer.py
@@ -11,7 +11,7 @@ import pygame
 import pygame.freetype
 from pygame import Surface, display
 
-from roboarena.shared.block import voidBlock
+from roboarena.shared.block import VoidBlock
 from roboarena.shared.utils.rect import Rect
 from roboarena.shared.utils.vector import Vector
 
@@ -177,13 +177,17 @@ class Renderer:
         self._fps_counter.render(self._screen)
         display.flip()
 
+    @cached_property
+    def void_block(self) -> VoidBlock:
+        return VoidBlock()
+
     # @log_durations(logger.debug, "_render_background: ", "ms")
     def _render_background(self, ctx: RenderCtx) -> None:
         self._screen.fill((0, 0, 0))
         for y in range(floor(ctx.fov.top_left.y), ceil(ctx.fov.bottom_right.y)):
             for x in range(floor(ctx.fov.top_left.x), ceil(ctx.fov.bottom_right.x)):
                 pos_gu = Vector(x, y)
-                block = self._game.level.get(pos_gu) or voidBlock
+                block = self._game.level.get(pos_gu) or self.void_block
                 block.render(pos_gu * 1.0, ctx)
 
     # @log_durations(logger.debug, "_render_entities: ", "ms")

--- a/src/roboarena/shared/util.py
+++ b/src/roboarena/shared/util.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -6,6 +7,8 @@ from random import getrandbits
 from typing import Any, Callable, Generator, NoReturn
 
 import numpy as np
+import pygame
+from pygame import Surface
 
 from roboarena.shared.utils.vector import Vector
 
@@ -47,6 +50,10 @@ def gen_coord_space(
     coords = np.array(np.meshgrid(lnx, lny)).ravel("F").reshape(-1, 2).astype(int)
 
     return [Vector.from_sequence(coord) for coord in coords]
+
+
+def enumerate2d[T](iter: Iterable[Iterable[T]]) -> Iterable[tuple[tuple[int, int], T]]:
+    return [((i, j), v) for i, row in enumerate(iter) for j, v in enumerate(row)]
 
 
 def dict_diff_keys[K, V](dict1: dict[K, V], dict2: dict[K, V]) -> dict[K, V]:
@@ -114,3 +121,11 @@ def stopAll(*stoppables: Stoppable) -> None:
 @dataclass(frozen=True)
 class Stopped:
     pass
+
+
+def graphic_path(path: str) -> str:
+    return os.path.join(os.path.dirname(__file__), "..", "resources", "graphics", path)
+
+
+def load_graphic(path: str) -> Surface:
+    return pygame.image.load(graphic_path(path))


### PR DESCRIPTION
The `tilesmap2levelmap` function used to create Blocks and therefore load the respective textures on each conversion.  
This is now fixed by storing real `Block`s in `Tile`s, since the `BlockCtx` was not used anywhere else.

In addition the function was massively simplified for readability and the type errors were fixed.