### PR TITLE
fix: Flickering Lines When Aspect Ratio != 1:1

### DIFF
--- a/src/roboarena/shared/constants.py
+++ b/src/roboarena/shared/constants.py
@@ -132,14 +132,14 @@ class Colors:
 class TextureSize:
 
     BUTTON_HEIGHT = 1.3
-    TEXT_WIDTH = 15
+    TEXT_WIDTH = 10
     BLOCK_WIDTH = 1.0
     BULLET_TEXTURE = Vector(1.0, 1.0)
     WEAPON_WIDTH = 0.75
     WEAPON_HEIGHT = 0.6
     PLAYER_WIDTH = 1.0
     ENEMY_WIDTH = 1.5
-    GAME_UI_HEIGHT = 1.5
+    GAME_UI_HEIGHT = 1.0
 
 
 class MusicPaths:
@@ -292,6 +292,10 @@ class NetworkConstants:
     SERVER_IP = 0x00000000
     VSYNC = True
     INITIAL_ACKNOLEDGEMENT: Acknoledgement = -1
+
+
+class GraphicConstants:
+    GU_PER_SCREEN = 20.0
 
 
 class PerlinNoiseConstants:

--- a/src/roboarena/shared/rendering/renderer.py
+++ b/src/roboarena/shared/rendering/renderer.py
@@ -133,8 +133,9 @@ class RenderCtx:
     """
 
     @cached_property
-    def px_per_gu(self) -> float:
-        return self.screen.get_width() / GU_PER_SCREEN
+    def px_per_gu(self) -> int:
+        px_per_gu = floor(self.screen.get_width() / GU_PER_SCREEN)
+        return px_per_gu - (px_per_gu % 10)
 
     def gu2px(self, vector: Vector[float]) -> Vector[int]:
         return (vector * self.px_per_gu).ceil()

--- a/src/roboarena/shared/rendering/renderer.py
+++ b/src/roboarena/shared/rendering/renderer.py
@@ -15,6 +15,7 @@ import pygame.freetype
 from pygame import Surface, display
 
 from roboarena.shared.block import void
+from roboarena.shared.constants import GraphicConstants
 from roboarena.shared.game import OutOfLevelError
 from roboarena.shared.rendering.util import draw_arrow
 from roboarena.shared.types import EntityId
@@ -36,7 +37,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(f"{__name__}")
 
 
-GU_PER_SCREEN = 25.0
 FOV_OVERLAP_GU = 1.0
 
 type FieldOfView = Rect
@@ -134,8 +134,8 @@ class RenderCtx:
 
     @cached_property
     def px_per_gu(self) -> int:
-        px_per_gu = floor(self.screen.get_width() / GU_PER_SCREEN)
-        return px_per_gu - (px_per_gu % 10)
+        px_per_gu = ceil(self.screen.get_width() / GraphicConstants.GU_PER_SCREEN)
+        return px_per_gu // 10 * 10
 
     def gu2px(self, vector: Vector[float]) -> Vector[int]:
         return (vector * self.px_per_gu).ceil()


### PR DESCRIPTION
- 1st change: ``gu2px`` now rounds up (``ceil``) instead of down (``floor``). This means that blocks can overlap minimally, but black lines are no longer visible.

- 2nd change: ``px_per_gu`` now returns an ``int`` instead of a ``float`` and the number is always divisible by 10. After some trial and error, this always results in the perfect number for any screen size, where the blocks in the background move cleanly and smoothly without flickering. 
This means that the blocks no longer scale linearly with the screen size, but there are no errors due to decimal numbers.

Resolves: #58 

Resolves: #60 