### PR TITLE
Player Wall Collision

### DIFF
--- a/src/roboarena/client/client.py
+++ b/src/roboarena/client/client.py
@@ -153,6 +153,7 @@ class GameState(SharedGameState):
     _client_id: ClientId
     _entity_id: EntityId
     _entity: ClientInputHandler
+    env = "client"
     entities: dict[EntityId, ClientEntityType]
     markers: deque[Marker]
     level: "Level"

--- a/src/roboarena/server/level_generation/tileset.py
+++ b/src/roboarena/server/level_generation/tileset.py
@@ -298,7 +298,7 @@ cross = Tile(
     ),
     edges=(e_floor, e_floor, e_floor, e_floor),
 )
-cross_r = Tile(
+cross_room = Tile(
     (
         (v, v, v, v, v, v, v, v, v, v, w, f, f, f, w, v, v, v, v, v, v, v, v, v, v),
         (v, v, v, v, v, v, v, v, v, v, w, f, f, f, w, v, v, v, v, v, v, v, v, v, v),
@@ -369,6 +369,8 @@ tiles = bidict(
         *zip("┏┓┛┗", rotations(corner_room)),
         *zip("┬┤┴├", rotations(tee)),
         *zip("┳┫┻┣", rotations(tee_room)),
+        *zip("┼", [cross]),
+        *zip("╋", [cross_room]),
         ("█", fallback),
         # (" ", None),
     )
@@ -390,5 +392,5 @@ tiles = bidict(
 # ███│█│███│██
 # ███├─┴─┬─┤██
 # """
-# tileset = Tileset.from_example(example, dict(str_tile_dict), fallback)
-tileset = Tileset.from_edges(tiles.values(), fallback)
+# tileset = Tileset.from_example(example, dict(tiles), fallback, tee)
+tileset = Tileset.from_edges(tiles.values(), fallback, cross)

--- a/src/roboarena/server/level_generation/wfc.py
+++ b/src/roboarena/server/level_generation/wfc.py
@@ -168,6 +168,15 @@ class WFC:
     """Positions explicitly requested as arguments to `collapse`."""
     _entropy_store: MinEntropyStore = field(init=False, factory=MinEntropyStore)
 
+    @staticmethod
+    def from_map(tileset: Tileset, map: dict[TilePosition, Tile]) -> "WFC":
+        wfc = WFC(tileset)
+        for p, t in map.items():
+            wfc.map[p] = one_hot(t)
+            wfc._not_collapsed.add(p)
+            wfc._entropy_store.add(p, 1)
+        return wfc
+
     def collapse(self, positions: Iterable[TilePosition]) -> WFCUpdate:
         """Guarantee positions to be collapsed and return newly collapsed"""
         positions = set(positions)

--- a/src/roboarena/server/server.py
+++ b/src/roboarena/server/server.py
@@ -110,6 +110,7 @@ class GameState(SharedGameState):
     _logger = logging.getLogger(f"{__name__}.GameState")
     _server: "Server"
     _clients: dict[ClientId, ClientInfo]
+    env = "server"
     entities: bidict[EntityId, ServerEntityType]
     markers: deque[Marker]
     _deleted_entities: list[ServerEntityType]

--- a/src/roboarena/server/server.py
+++ b/src/roboarena/server/server.py
@@ -215,7 +215,7 @@ class GameState(SharedGameState):
         entity = ServerPlayerRobot(
             self,
             100,
-            (Vector(10.0, 5.0), Vector(1.0, 0.0)),
+            (Vector(12.5, 12.5), Vector(1.0, 0.0)),
             Color(0, 255, 0),
             self.dispatch_factory(None, entity_id),
         )

--- a/src/roboarena/shared/game.py
+++ b/src/roboarena/shared/game.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC
 from collections.abc import Iterable
-from typing import overload
+from typing import Literal, overload
 
 from roboarena.server.level_generation.level_generator import Level
 from roboarena.shared.block import wall
@@ -15,6 +15,7 @@ logger = logging.getLogger(f"{__name__}")
 
 
 class GameState(ABC):
+    env: Literal["server"] | Literal["client"]
     entities: dict[EntityId, Entity]
     level: Level
     game_ui: GameUI

--- a/src/roboarena/shared/utils/vector.py
+++ b/src/roboarena/shared/utils/vector.py
@@ -139,6 +139,12 @@ class Vector[T: (int, float)]:
     def mirror(self) -> "Vector[T]":
         return Vector(self.y, self.x)
 
+    def to_float(self) -> "Vector[float]":
+        return Vector(float(self.x), float(self.y))
+
+    def to_int(self) -> "Vector[int]":
+        return Vector(int(self.x), int(self.y))
+
     @staticmethod
     def zero() -> "Vector[float]":
         return Vector(0, 0)


### PR DESCRIPTION
Contains three changes:

- Constistent player spawn position: Modifies wfc to be able to place an initial tile and set the player spawn in the center.
- Player wall collision
- @weiserhase @JulesOxe Place `env: Literal["server"] | Literal["client"]` field on game. This is useful for debugging shared components.  
  Production code should probably not rely on this but instead do proper code seperation for better readability.

Resolves #29