### PR TITLE
Weopon and Health Events on Client

### DIFF
--- a/src/roboarena/client/client.py
+++ b/src/roboarena/client/client.py
@@ -176,7 +176,9 @@ class GameState(SharedGameState):
             if not isinstance(spawn, ServerSpawnRobotEvent):
                 self._logger.critical("client entity no robot")
                 raise Exception("client entity no robot")
-            entity = ClientPlayerRobot(self, spawn.health, spawn.motion, spawn.color)
+            entity = ClientPlayerRobot(
+                self, spawn.health, spawn.motion, spawn.color, spawn.weapon
+            )
             self.entities[spawn.id] = entity
             self._entity = entity
             self._logger.debug(f"intialized client entity: {self._entity}")
@@ -195,8 +197,10 @@ class GameState(SharedGameState):
         match event:
             case ServerEntityEvent(id, name, payload):
                 self.entities[id].on_server(name, payload, msg.last_ack, t_msg)
-            case ServerSpawnRobotEvent(id, health, motion, color):
-                entity = ClientEnemyRobot(self, health, motion, color, last_ack, t_msg)
+            case ServerSpawnRobotEvent(id, health, motion, color, weapon):
+                entity = ClientEnemyRobot(
+                    self, health, motion, color, weapon, last_ack, t_msg
+                )
                 self.entities[id] = entity
             case ServerSpawnPlayerBulletEvent(id, position, velocity):
                 entity = ClientPlayerBullet(
@@ -258,7 +262,7 @@ class GameState(SharedGameState):
 
             input = self.get_input(dt)
             ack = self.dispatch(ClientInputEvent(input, dt))
-            self._entity.on_input(input, dt, ack)
+            self._entity.on_input(input, dt, ack, t)
 
             for _, entity in self.entities.items():
                 entity.tick(dt, t)

--- a/src/roboarena/client/entity.py
+++ b/src/roboarena/client/entity.py
@@ -273,7 +273,7 @@ class ClientPlayerRobot(PlayerRobot, ClientEntity, ClientInputHandler):
     color: PassiveRemoteValue[Color]
     weapon: ClientWeapon
     aim: Position
-    events: EventTarget[MovedEvent | HitEvent | DeathEvent]
+    events: EventTarget[HitEvent | DeathEvent | MovedEvent | ShotEvent]
 
     def __init__(
         self,
@@ -304,6 +304,7 @@ class ClientPlayerRobot(PlayerRobot, ClientEntity, ClientInputHandler):
             ChangedByInputEvent,
             lambda e: (dispatch(MovedEvent()) if e.old[0] != e.new[1] else None),  # type: ignore
         )
+        self.health.events.add_listener(ShotEvent, dispatch)
 
     def on_input(self, input: Input, dt: Time, ack: Acknoledgement, t: Time):
         self.motion.on_input((input, dt), ack)
@@ -385,7 +386,7 @@ class ClientEnemyRobot(EnemyRobot, ClientEntity):
     motion: InterpolatedValue[Motion, None]
     color: PassiveRemoteValue[Color]
     weapon: ClientWeapon
-    events: EventTarget[HitEvent | DeathEvent]
+    events: EventTarget[HitEvent | DeathEvent | ShotEvent]
 
     def __init__(
         self,
@@ -413,6 +414,7 @@ class ClientEnemyRobot(EnemyRobot, ClientEntity):
             ChangedByServerEvent,
             lambda e: dispatch(DeathEvent()) if e.new <= 0 else None,  # type: ignore
         )
+        self.health.events.add_listener(ShotEvent, dispatch)
 
     def on_server(
         self,

--- a/src/roboarena/server/server.py
+++ b/src/roboarena/server/server.py
@@ -43,6 +43,7 @@ from roboarena.shared.types import (
     ServerLevelUpdateEvent,
     ServerMarkerEvent,
     StartFrameEvent,
+    basic_weapon,
 )
 from roboarena.shared.util import (
     EventTarget,
@@ -134,6 +135,7 @@ class GameState(SharedGameState):
             100,
             (Vector(10.0, 1.0), Vector(1.0, 0.0)),
             Color(255, 0, 0),
+            basic_weapon,
             self.dispatch_factory(None, enemy_id),
         )
         self.entities[enemy_id] = enemy

--- a/src/roboarena/shared/types.py
+++ b/src/roboarena/shared/types.py
@@ -1,5 +1,6 @@
 from collections.abc import Collection, Iterable
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import pygame
@@ -65,6 +66,21 @@ class StartFrameEvent:
 class QuitEvent:
     """Fired when then user requests to quit the program"""
 
+
+@dataclass(frozen=True)
+class Weapon:
+    weapon_speed: float
+    """In shots per second"""
+    bullet_speed: float
+    """In gu per second"""
+    bullet_strength: int
+
+    @cached_property
+    def wepaon_cooldown(self):
+        return 1 / self.weapon_speed
+
+
+basic_weapon = Weapon(weapon_speed=1.5, bullet_speed=2, bullet_strength=10)
 
 """Communication protocol
 """
@@ -140,6 +156,7 @@ class ServerSpawnRobotEvent:
     health: int
     motion: Motion
     color: Color
+    weapon: Weapon
 
 
 @dataclass(frozen=True)

--- a/src/roboarena/shared/types.py
+++ b/src/roboarena/shared/types.py
@@ -82,6 +82,17 @@ class Weapon:
 
 basic_weapon = Weapon(weapon_speed=1.5, bullet_speed=2, bullet_strength=10)
 
+
+@dataclass(frozen=True)
+class HitEvent:
+    """Fired after entity was hit"""
+
+
+@dataclass(frozen=True)
+class DeathEvent:
+    """Fired when entity dies"""
+
+
 """Communication protocol
 """
 


### PR DESCRIPTION
Provides `ShotEvent`, `HitEvent` and `DeathEvent` on both `ClientPlayerEntity` and `ClientEnemyEntity`.

Resolves #75
Relates to #71