### PR TITLE
feat(timer): add periodic-printing+console clearing

### DIFF
--- a/src/roboarena/shared/utils/statistics.py
+++ b/src/roboarena/shared/utils/statistics.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from math import nan
 from typing import Callable, Optional
 
+from roboarena.shared.utils.system_utils import cls
 from roboarena.shared.utils.table_printer import print_table
 
 
@@ -106,11 +107,11 @@ class StatsCollection:
                 functions=[mean, stddev, min, max],
                 unitless=set(),
             )
-        self.groups: dict[str, list[str]] = defaultdict(list)
+        self.groups: dict[str, set[str]] = defaultdict(set)
 
     def clear(self):
         self._stats: dict[str, Stats] = {}
-        self.groups: dict[str, list[str]] = defaultdict(list)
+        self.groups: dict[str, set[str]] = defaultdict(set)
 
     def register_metrics(
         self,
@@ -134,9 +135,9 @@ class StatsCollection:
         )
         self._stats[label] = stats
         if group is not None:
-            self.groups[group].append(label)
+            self.groups[group].add(label)
         else:
-            self.groups["_"].append(label)
+            self.groups["_"].add(label)
 
     def print_all_stats(self) -> None:
         header = ["Label"] + self._columns
@@ -153,6 +154,7 @@ class StatsCollection:
             # Add a separator between groups if there are more groups to print
             if group_name != sorted_groups[-1][0]:
                 config.append(["__sep"])
+        cls()  # Clear the Console for all types of systems
         print_table(config)
 
 

--- a/src/roboarena/shared/utils/system_utils.py
+++ b/src/roboarena/shared/utils/system_utils.py
@@ -1,0 +1,5 @@
+import os
+
+
+def cls():
+    os.system("cls" if os.name == "nt" else "clear")

--- a/src/roboarena/shared/utils/table_printer.py
+++ b/src/roboarena/shared/utils/table_printer.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from functools import partial
 from typing import Any
@@ -72,7 +73,7 @@ def print_table(
     data: list[list[Any]], sep: Seperator = Seperator()  # noqa: B008
 ) -> None:
     lines = construct_table(data, sep, False)
-    print("\n".join(lines))
+    print("\n".join(lines), flush=True)
 
 
 if __name__ == "__main__":
@@ -85,4 +86,6 @@ if __name__ == "__main__":
         ["__sep"],
         ["XMR", 172.367 / 141.9, 172.367],
     ]
-    print_table(config)
+    for _ in range(10):
+        print_table(config)
+        time.sleep(1)


### PR DESCRIPTION
Add Timer run logic to allow for periodic printing of stats with/ without reset every n runs. 
Allows to full cleat the console propperly on all platforms     