### PR TITLE
fix(timer): increment run counter

### DIFF
--- a/src/roboarena/shared/utils/timer.py
+++ b/src/roboarena/shared/utils/timer.py
@@ -65,6 +65,7 @@ class Timer:
         self.timings[label].append(elapsed_time)
 
     def end_run(self) -> None:
+        self._c += 1
         while len(self.current) > 0:
             self.tick_end()
         if self._periodic_timing is None:


### PR DESCRIPTION
Fix the bug with the counter where it prints every round becaus the run counter is never incremented.