### PR TITLE
Fix Pytest Warning

### DIFF
--- a/perf_test/frame_cache_test.py
+++ b/perf_test/frame_cache_test.py
@@ -103,7 +103,7 @@ class GameState:
         self.events.listeners("test")
 
 
-class Test:
+class Target:
     _game: GameState
 
     def __init__(self) -> None:
@@ -125,7 +125,7 @@ class Test:
 
 
 if __name__ == "__main__":
-    game_state = Test()
+    game_state = Target()
 
     def gen_data():
         return (random.randint(0, 200), random.randint(0, 200))


### PR DESCRIPTION
Fix pytest warning about being unable to collect some tests by renaming the class to not start with "Test".