### PR TITLE
Move through Narrow Corridors

### DIFF
--- a/src/roboarena/shared/constants.py
+++ b/src/roboarena/shared/constants.py
@@ -6,6 +6,5 @@ VSYNC = True
 
 
 class PlayerConstants:
-    MAX_SPEED = 5
-    ACCELEARTE = 0.7
-    DECELERATE = 0.9
+    ACCELEARTE = 0.6
+    DECELERATE = 0.1

--- a/src/roboarena/shared/entity.py
+++ b/src/roboarena/shared/entity.py
@@ -106,7 +106,7 @@ class PlayerRobot(Entity):
     def __init__(self, game: "GameState") -> None:
         super().__init__(game)
         self.collision = CollideAroundCenter(  # type: ignore
-            lambda: self.motion.get()[0], Rect.from_width_height(Vector.one())
+            lambda: self.motion.get()[0], Rect.from_size(Vector.from_scalar(0.95))
         )
 
     @property
@@ -196,7 +196,7 @@ class EnemyRobot(Entity):
     def __init__(self, game: "GameState", motion: Motion) -> None:
         super().__init__(game)
         self.collision = CollideAroundCenter(
-            lambda: self.motion.get()[0], Rect.from_width_height(Vector.one())
+            lambda: self.motion.get()[0], Rect.from_size(Vector.from_scalar(0.95))
         )
         self.initial_position = motion[0]
 

--- a/src/roboarena/shared/game.py
+++ b/src/roboarena/shared/game.py
@@ -40,6 +40,19 @@ class GameState(ABC):
         """Required for `frame_cache_method`"""
         return self
 
+    def blocking(
+        self, collider: Rect | Entity, mode: Literal["robot"] | Literal["bullet"]
+    ) -> bool:
+        return any(
+            (mode == "robot" and e.blocks_robot)
+            or (mode == "bullet" and e.blocks_bullet)
+            for e in self.collidingEntities(collider)
+        ) or any(
+            (mode == "robot" and b.blocks_robot)
+            or (mode == "bullet" and b.blocks_bullet)
+            for b in self.colliding_blocks(collider).values()
+        )
+
     @overload
     def collidingEntities(self, collider: Entity) -> Iterable[Entity]: ...
 

--- a/src/roboarena/shared/types.py
+++ b/src/roboarena/shared/types.py
@@ -19,8 +19,8 @@ type EntityId = int
 type ClientId = int
 
 type Position = Vector[float]
-type Orientation = Vector[float]
-type Motion = tuple[Position, Orientation]
+type Velocity = Vector[float]
+type Motion = tuple[Position, Velocity]
 type Color = pygame.Color
 
 type Entities = dict[EntityId, "Entity"]

--- a/src/roboarena/shared/utils/vector.py
+++ b/src/roboarena/shared/utils/vector.py
@@ -5,6 +5,14 @@ from typing import Callable, Sequence, overload
 from pygame import Vector2
 
 
+def sign(x: int | float) -> int:
+    if x > 0:
+        return 1
+    if x < 1:
+        return -1
+    return 0
+
+
 @dataclass(frozen=True)
 class Vector[T: (int, float)]:
     x: T
@@ -130,6 +138,9 @@ class Vector[T: (int, float)]:
 
     def normalize(self) -> "Vector[float]":
         return self / self.length()
+
+    def sign(self) -> "Vector[int]":
+        return Vector(sign(self.x), sign(self.y))
 
     def distance_to(self, to: "Vector[T]") -> float:
         return (to - self).length()  # type: ignore


### PR DESCRIPTION
Enables the player to move through 1 block wide corridors.

To achieve this, this pr reimplements movement to use a more physics-like movement simulation and enables the player to slide along a wall when moving diagonally against it.

@weiserhase The movement logic, especially the lower part of the `PlayerEntity.move` function might be interesting to you for implementing the enemy ai.

Resolves #101.